### PR TITLE
dequote if_fullname if_shortname

### DIFF
--- a/generate_topology.py
+++ b/generate_topology.py
@@ -95,7 +95,18 @@ interface_full_name_map = {
 }
 
 
+def dequote(s):
+    """
+    If a string has single or double quotes around it, remove them.
+    Make sure the pair of quotes match.
+    If a matching pair of quotes is not found, return the string unchanged.
+    """
+    if len(s) >= 2 and (s[0] == s[-1]) and s.startswith(("'", '"')):
+        return s[1:-1]
+    return s
+
 def if_fullname(ifname):
+    ifname = dequote(ifname)
     for k, v in interface_full_name_map.items():
         if ifname.startswith(v):
             return ifname
@@ -105,6 +116,7 @@ def if_fullname(ifname):
 
 
 def if_shortname(ifname):
+    ifname = dequote(ifname)
     for k, v in interface_full_name_map.items():
         if ifname.startswith(v):
             return ifname.replace(v, k)


### PR DESCRIPTION
When generating a topology with EOS devices, links between two EOS boxes would always get duplicated. The issue is caused by EOS returning LLDP neighbor's interface name in double-quotes. It should be safe to always `dequote` interface names as part of `if_fullname` and `if_shortname` functions. The fix was tested in on a simple 4-node spine-leaf topology.

Here is an example of `show lldp neighbor details` output from EOS:

````
Interface Ethernet1 detected 1 LLDP neighbors:

  Neighbor 2a19.9ed4.b06c/"Ethernet1", age 28 seconds
  Discovered 1:00:27 ago; Last changed 1:00:27 ago
  - Chassis ID type: MAC address (4)
    Chassis ID     : 2a19.9ed4.b06c
  - Port ID type: Interface name(5)
    Port ID     : "Ethernet1"
  - Time To Live: 120 seconds
  - System Name: "pod1"
  - System Capabilities : Bridge, Router
    Enabled Capabilities: Bridge, Router
  - Management Address Subtype: IPv4
    Management Address        : 10.0.254.254
    Interface Number Subtype  : ifIndex (2)
    Interface Number          : 5000000
    OID String                :
  - IEEE802.1 Port VLAN ID: 0
  - IEEE802.1/IEEE802.3 Link Aggregation
    Link Aggregation Status: Capable, Disabled (0x01)
    Port ID                : 0
  - IEEE802.3 Maximum Frame Size: 9236 bytes
````